### PR TITLE
Replace commit message with id in slack message

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ runs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "*Last commit*\n<${{ github.event.head_commit.url }}|${{ github.event.head_commit.message }}>"
+                      "text": "*Last commit*\n<${{ github.event.head_commit.url }}|${{ github.event.head_commit.id }}>"
                     }
                   }
                 ]


### PR DESCRIPTION
The message we receive is the whole thing, not just the header.